### PR TITLE
Updating to Redis replication protocol vsn 0006

### DIFF
--- a/src/nsync.hrl
+++ b/src/nsync.hrl
@@ -4,7 +4,14 @@
 -define(REDIS_ZSET, 3).
 -define(REDIS_HASH, 4).
 
--define(REDIS_EXPIRETIME, 253).
+-define(REDIS_ZMAP, 9).
+-define(REDIS_ZLIST, 10).
+-define(REDIS_INTSET, 11).
+-define(REDIS_SSZLIST, 12).
+-define(REDIS_HMAPZLIST, 13).
+
+-define(REDIS_EXPIRETIME_MS, 252).
+-define(REDIS_EXPIRETIME_SEC, 253).
 -define(REDIS_SELECTDB, 254).
 -define(REDIS_EOF, 255).
 


### PR DESCRIPTION
Adds support for ziplists, intsets, sorted sets as ziplists, and
hashmaps in ziplist encodings.

Support for zipmaps would be needed to fully support 0002 through 0005,
but they've been untested and marked as incompatible as such, at least
until someone tests and implements missing things if required.

based on
https://github.com/sripathikrishnan/redis-rdb-tools/wiki/Redis-RDB-Dump-File-Format
