### PR TITLE
Fix potential connection error

### DIFF
--- a/src/nsync.erl
+++ b/src/nsync.erl
@@ -77,16 +77,16 @@ start_link(Opts) ->
 %%====================================================================
 init([Opts, CallerPid]) ->
     case init_state(Opts, CallerPid) of
-        {ok, State} ->
+        {ok, State = #state{}} ->
             {ok, State};
         Error ->
             {stop, Error}
     end.
 
-handle_call(_Request, _From, State) ->
+handle_call(_Request, _From, State = #state{}) ->
     {reply, ignore, State}.
 
-handle_cast(_Msg, State) ->
+handle_cast(_Msg, State = #state{}) ->
     {noreply, State}.
 
 handle_info({tcp, Socket, Data}, #state{callback=Callback,
@@ -146,7 +146,7 @@ handle_info({tcp_error, _ ,_}, #state{callback=Callback,
             {stop, Error, State}
     end;
 
-handle_info(_Info, State) ->
+handle_info(_Info, State = #state{}) ->
     {noreply, State}.
 
 terminate(_Reason, _State) ->
@@ -216,6 +216,8 @@ authenticate(Socket, Auth) ->
                     ok;
                 {ok, <<"+OK\r\n">>} ->
                     ok;
+                {ok, Other} ->
+                    {error, {ok, Other}};
                 Error ->
                     Error
             end;


### PR DESCRIPTION
if the value received when connecting is {ok, ...} where the pattern
doesn't match, the one expected and other packets are received, the
result returned there will not be discarded -- it will be taken as the
new state and all future calls will fall through the blank match
patterns

So if the connection or auth fails (say it tries to reconnect during
some password change), no event will ever happen and as long as redis
doesn't kill the connection things will keep going on. But we won't
necessarily know the connection has been killed because all events will
be auto-ignored.
