### PR TITLE
Fix RDB, add heartbeats.

### DIFF
--- a/test/nsync_SUITE.erl
+++ b/test/nsync_SUITE.erl
@@ -1,0 +1,71 @@
+-module(nsync_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-compile(export_all).
+
+%% taken from nysnc.erl
+-record(state, {callback, caller_pid, socket, opts, 
+                state, buffer, rdb_state}).
+
+all() -> [heartbeat_up, heartbeat_loading].
+
+heartbeat_up(_Config) ->
+    Self = self(),
+    {ok,Port} = gen_tcp:listen(0, []),
+    Pid = proc_lib:spawn(fun() ->
+        gen_server:enter_loop(
+            nsync,
+            [],
+            #state{callback=fun(Event) -> Self ! Event end,
+                   socket=Port, buffer= <<>>, state=up,
+                   opts=[{port,badarg}]}
+        )
+    end),
+    Ref = erlang:monitor(process, Pid),
+    Pid ! timeout,
+    #state{state=heartbeat} = get_state(sys:get_status(Pid)),
+    Pid ! {tcp, Port, <<"+PONG\r\n">>},
+    #state{state=up} = get_state(sys:get_status(Pid)),
+    Pid ! timeout,
+    #state{state=heartbeat} = get_state(sys:get_status(Pid)),
+    Pid ! timeout,
+    %% We passed in a bad port to see a crash when trying to reconnect.
+    %% the port 'badarg' sent in the options should cause an invalid
+    %% port error. If we catch it, it works as planned.
+    receive
+        {'DOWN', Ref, process, Pid, {error,invalid_host_or_port}} -> ok
+        after 5000 ->
+            exit(Pid, shutdown),
+            exit(no_heartbeat)
+    end.
+
+heartbeat_loading(_Config) ->
+    Self = self(),
+    {ok,Port} = gen_tcp:listen(0, []),
+    Pid = proc_lib:spawn(fun() ->
+        gen_server:enter_loop(
+            nsync,
+            [],
+            #state{callback=fun(Event) -> Self ! Event end,
+                   socket=Port, buffer= <<>>, state=loading,
+                   opts=[]}
+        )
+    end),
+    Ref = erlang:monitor(process, Pid),
+    %% always die in a sync timeout
+    Pid ! timeout,
+    receive
+        {'DOWN', Ref, process, Pid, rdb_load_timeout} -> ok
+        after 5000 ->
+            exit(Pid, shutdown),
+            exit(no_heartbeat)
+    end.
+
+%%%%%%%%%%%%%%%
+%%% HELPERS %%%
+%%%%%%%%%%%%%%%
+get_state({status,_Pid,_Mod,List}) ->
+    Datas = [proplists:get_all_values(data,L)
+        || L = [_|_] <- List, proplists:get_value(data,L) =/= undefined],
+    [State] = [State || {"State",State} <- lists:flatten(Datas)],
+    State.
+


### PR DESCRIPTION
1.
Newer redis versions appear to be sending PINGs from time to time to
make sure the communication is open. On older copies, though, there is
no heartbeat and thus no way to know if the communication is just silent
or down (without a reset packet having been sent to notify the reader).

This req adds a heartbeat with a long delay (15 minutes +) that will
shut down nsync (and let a supervisor restart it) if the server doesn't
answer to a PING command (with "+PONG\r\n") in the next few minutes.

2.
Ziplists with lengths greater than 63 bytes and up to 16383 bytes appear
not to be encoded as small endian like the rest. The original source at
https://github.com/sripathikrishnan/redis-rdb-tools/blob/master/docs/RDB_File_Format.textile
doesn't mention the endianness, so 'native' is being used. This will
default to 'big' on most architectures, maybe implode on clusters with
varying endianness.

This also includes a fix for an explicitly big endian format for
String values with length greater than or equal to 16384 bytes, as
showin at sripathikrishnan/redis-rdb-tools@4a4b7e0
in the original project.

3.
The zipmap entries allow to dynamically update the values, but not the
keys. The 'Free' entry may only be present before the value, not the key.

This patch fixes the zipmap entry parsing so that it is aware of what is
a key and what is a value, rather than assuming they are uniform.
